### PR TITLE
Don't assume lines end with a semicolon

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -26,7 +26,7 @@ module.exports.processors = {
       preprocess: function(text, filename) {
           // here, you can strip out any non-JS content
           // and split into multiple strings to lint
-          text = text.replace(/=[\s+]?<%([\S\s]*?)\%>;/g, '= IgnoredERB; /* global IgnoredERB */');
+          text = text.replace(/=[\s+]?<%([\S\s]*?)\%>(;)?/g, '= IgnoredERB$2 /* global IgnoredERB */');
 
           text = text.replace(/<%([\S\s]*?)\%>\,?/g, '/* Ignored ERB */');
 


### PR DESCRIPTION
This fixes a bug where the regex to replace an expression like

    let a = <%= Something::From::Erb %>;

failed to match if written without a semicolon like

    let a = <%= Something::From::Erb %>

The replacement string preserves the semicolon if it's there and leaves
it off if it is not.